### PR TITLE
Retain custom headers when unserializing

### DIFF
--- a/src/TopicMessageSerializer.php
+++ b/src/TopicMessageSerializer.php
@@ -32,11 +32,12 @@ class TopicMessageSerializer implements MessageSerializer
     {
         $messageClass = $this->topic->getMessageClassFromType($rawMessage->messageType);
         $payload = $messageClass::fromPayload(json_decode($rawMessage->messagePayload, true));
+        $headers = json_decode($rawMessage->headerPayload, true);
         $message = new Message($payload, [
             Header::MESSAGE_ID => $rawMessage->messageId,
             Header::MESSAGE_TYPE => $rawMessage->messageType,
             Header::MESSAGE_TOPIC => $rawMessage->topic,
-        ]);
+        ] + $headers);
         if($rawMessage->publishedAtFormat !== null){
             return $message->withTimeOfRecording($rawMessage->publishedAt, $rawMessage->publishedAtFormat);
         }

--- a/tests/TopicMessageSerializerTest.php
+++ b/tests/TopicMessageSerializerTest.php
@@ -22,13 +22,16 @@ class TopicMessageSerializerTest extends TestCase
     {
         $topicSerializer = new TopicMessageSerializer($topic);
         $message = new Message($publicMessage, [
-            Header::MESSAGE_ID => 'foo'
+            Header::MESSAGE_ID => 'foo',
+            'custom-header' => 'bar',
         ]);
         $message = $message->withTimeOfRecording(new DateTimeImmutable('now'));
         $rawMessage = $topicSerializer->serializeMessage($message);
 
         $reconstructedMessage = $topicSerializer->unserializePayload($rawMessage);
         $this->assertEquals($publicMessage, $reconstructedMessage->payload());
+        $this->assertEquals('foo', $reconstructedMessage->headers()[Header::MESSAGE_ID]);
+        $this->assertEquals('bar', $reconstructedMessage->headers()['custom-header']);
     }
 
     public function providesMessages(): \Generator


### PR DESCRIPTION
Not sure if that's desired behavior, but seems like it should be as there is no way to recover any other headers (apart from those 3) in projectors